### PR TITLE
Skip rewriting snapshot based sources.list when apt < 0.7.21

### DIFF
--- a/examples/debian.sh
+++ b/examples/debian.sh
@@ -241,7 +241,11 @@ else
 	sourcesListArgs+=( --no-deb822 )
 	sourcesListFile='/etc/apt/sources.list'
 fi
-debuerreotype-debian-sources-list "${sourcesListArgs[@]}" --snapshot "$rootfsDir" "$suite"
+sourcesListSnapshotArg=
+if dpkg --compare-versions "$aptVersion" '>=' '0.7.21~'; then
+	sourcesListSnapshotArg=--snapshot
+fi
+debuerreotype-debian-sources-list "${sourcesListArgs[@]}" $sourcesListSnapshotArg "$rootfsDir" "$suite"
 [ -s "$rootfsDir$sourcesListFile" ] # trust, but verify
 
 debuerreotype-minimizing-config "$rootfsDir"
@@ -426,7 +430,7 @@ if [ -n "$codenameCopy" ]; then
 		targetBase="$variantDir/rootfs"
 
 		# point sources.list back at snapshot.debian.org temporarily (but this time pointing at $codename instead of $suite)
-		debuerreotype-debian-sources-list --snapshot "${sourcesListArgs[@]}" "$rootfs" "$codename"
+		debuerreotype-debian-sources-list $sourcesListSnapshotArg "${sourcesListArgs[@]}" "$rootfs" "$codename"
 
 		create_artifacts "$targetBase" "$rootfs" "$codename" "$variant"
 	done

--- a/scripts/debuerreotype-init
+++ b/scripts/debuerreotype-init
@@ -163,7 +163,14 @@ if [ -n "$addGpgvIgnore" ]; then
 fi
 
 if [ -z "$nonDebian" ]; then
-	"$thisDir/debuerreotype-debian-sources-list" --snapshot \
+	sourcesListSnapshotArg=
+	aptVersion="$("$thisDir/.apt-version.sh" "$targetDir")"
+	if dpkg --compare-versions "$aptVersion" '>=' '0.7.21~'; then
+		# http://snapshot.debian.org began to use http Location header
+		# that is only supported by apt >= 0.7.21.
+		sourcesListSnapshotArg=--snapshot
+	fi
+	"$thisDir/debuerreotype-debian-sources-list" $sourcesListSnapshotArg \
 		$([ -z "$debianEol" ] || echo '--eol') \
 		$([ -z "$debianPorts" ] || echo '--ports') \
 		"$targetDir" "$suite"


### PR DESCRIPTION
With `-o Debug::pkgAcquire=true -o Debug::Acquire=true -o Debug::Acquire::http=true`:
  ```
  Dequeuing /var/lib/apt/lists/partial/snapshot.debian.org_archive_debian-archive_20250123T071355Z_debian_dists_lenny_main_binary-alpha_Packages
  Fetching http://snapshot.debian.org/archive/debian-archive/20250123T071355Z/debian/dists/lenny/main/binary-alpha/Packages.gz
   to /var/lib/apt/lists/partial/snapshot.debian.org_archive_debian-archive_20250123T071355Z_debian_dists_lenny_main_binary-alpha_Packages
   Queue is: http:snapshot.debian.org
  Dequeuing /var/lib/apt/lists/partial/snapshot.debian.org_archive_debian-archive_20250123T071355Z_debian_dists_lenny_main_binary-alpha_Packages
  GET /archive/debian-archive/20250123T071355Z/debian-security/dists/lenny/updates/main/binary-alpha/Packages.gz HTTP/1.1
  Host: snapshot.debian.org
  Connection: keep-alive
  User-Agent: Debian APT-HTTP/1.3 (0.7.20.2)

  HTTP/1.1 302 FOUND
  ...
  location: /file/101ea9095ce6b1e5c5e9ec99cc6af70985f3a7a9
  ...
  content-type: text/html; charset=utf-8
  ...
  ```
This is only supported for apt >= 0.7.21. This change then skips rewritting sources.list file based on snapshot urls when apt version is smaller than required.